### PR TITLE
Fixes for SPlot Algo

### DIFF
--- a/HIN-16-004/Fitter/Macros/Utilities/initClasses.h
+++ b/HIN-16-004/Fitter/Macros/Utilities/initClasses.h
@@ -279,6 +279,21 @@ bool compareSnapshots(RooArgSet *pars1, const RooArgSet *pars2) {
 };
 
 
+bool setConstant( RooWorkspace& myws, string parName, bool CONST)
+{
+  if (myws.var(parName.c_str())) { 
+    myws.var(parName.c_str())->setConstant(CONST);
+    if (CONST) { cout << "[INFO] Setting parameter " << parName << " : " << myws.var(parName.c_str())->getVal() << " to constant value!" << endl; }
+  }
+  else if (!myws.function(parName.c_str())) { 
+    cout << "[ERROR] Parameter " << parName << " was not found!" << endl;
+    return false;
+  }
+
+  return true;
+};
+
+
 bool saveWorkSpace(RooWorkspace& myws, string outputDir, string FileName)
 {
   // Save the workspace
@@ -294,6 +309,43 @@ bool saveWorkSpace(RooWorkspace& myws, string outputDir, string FileName)
     file->Write(); file->Close(); delete file;
   }
   return true;
+};
+
+
+bool isCompatibleDataset(const RooDataSet& ds, const RooDataSet& ref, bool checkRange=true)
+{
+  // Check that the DataSets have the same number of events
+  if (ds.numEntries()!=ref.numEntries()){ cout << "[ERROR] DataSets " << ds.GetName() << " and " << ref.GetName() << " don't have the same number of events!" << endl; return false; }
+  if (ds.sumEntries()!=ref.sumEntries()){ cout << "[ERROR] DataSets " << ds.GetName() << " and " << ref.GetName() << " don't have the same sum of weights!" << endl; return false; }
+  // Check that the input DataSet have the same variables and distributions as the reference
+  const RooArgSet* listVar = ref.get();
+  TIterator* parIt = listVar->createIterator();
+  for (RooRealVar* it = (RooRealVar*)parIt->Next(); it!=NULL; it = (RooRealVar*)parIt->Next() ) {
+    string name = it->GetName();
+    if ( ds.get()->find(it->GetName()) == NULL ) { cout << "[ERROR] DataSet " << ds.GetName() << " does not contain the variable " << it->GetName() << " !" << endl; return false; }
+    if (checkRange) {
+      if ( it->getMin() != ((RooRealVar*)ds.get()->find(it->GetName()))->getMin() ) { cout << "[ERROR] " << it->GetName() << " Min Range disaggrement : "
+                                                                                           << ds.GetName() << " ( " << ((RooRealVar*)ds.get()->find(it->GetName()))->getMin() << " ) " << " and "
+                                                                                           << ref.GetName() << " ( " << it->getMin() << " ) " << " ! " << endl; return false; }
+      if ( it->getMax() != ((RooRealVar*)ds.get()->find(it->GetName()))->getMax() ) { cout << "[ERROR] " << it->GetName() << " Max Range disaggrement : "
+                                                                                           << ds.GetName() << " ( " << ((RooRealVar*)ds.get()->find(it->GetName()))->getMax() << " ) " << " and "
+                                                                                           << ref.GetName() << " ( " << it->getMax() << " ) " << " ! " << endl; return false; }
+    }
+    if ( ref.mean(*it) != ds.mean(*it) ) { cout << "[ERROR] " << it->GetName() << " Mean Value disaggrement : "
+                                                << ds.GetName() << " ( " << ds.mean(*it) << " ) " << " and "
+                                                << ref.GetName() << " ( " << ref.mean(*it) << " ) " << " ! " << endl; return false; }
+    if ( ref.moment(*it, 2) != ds.moment(*it, 2) ) { cout << "[ERROR] " << it->GetName() << " Variance Value disaggrement : "
+                                                          << ds.GetName() << " ( " << ds.moment(*it, 2) << " ) " << " and "
+                                                          << ref.GetName() << " ( " << ref.moment(*it, 2) << " ) " << " ! " << endl; return false; }
+    if ( ref.moment(*it, 3) != ds.moment(*it, 3) ) { cout << "[ERROR] " << it->GetName() << " 3rd Moment Value disaggrement : "
+                                                          << ds.GetName() << " ( " << ds.moment(*it, 3) << " ) " << " and "
+                                                          << ref.GetName() << " ( " << ref.moment(*it, 3) << " ) " << " ! " << endl; return false; }
+    if ( ref.moment(*it, 4) != ds.moment(*it, 4) ) { cout << "[ERROR] " << it->GetName() << " 4rd Moment Value disaggrement : "
+                                                          << ds.GetName() << " ( " << ds.moment(*it, 4) << " ) " << " and "
+                                                          << ref.GetName() << " ( " << ref.moment(*it, 4) << " ) " << " ! " << endl; return false; }
+  }
+  // DataSets are compatible if they passed all tests
+  cout << "[INFO] DataSets " << ds.GetName() << " and " << ref.GetName() << " are compatible!" << endl; return true;
 };
 
 
@@ -327,7 +379,7 @@ bool isFitAlreadyFound(RooArgSet *newpars, string FileName, string pdfName)
 };
 
 
-bool loadPreviousFitResult(RooWorkspace& myws, string FileName, string DSTAG, bool isPbPb, bool cutSideBand=false, bool loadNumberOfEvents=true)
+bool loadPreviousFitResult(RooWorkspace& myws, string FileName, string DSTAG, bool isPbPb, bool cutSideBand=false, bool loadNumberOfEvents=true, bool updateN=true)
 {
   if (gSystem->AccessPathName(FileName.c_str())) {
     cout << "[INFO] File " << FileName << " was not found!" << endl;
@@ -406,6 +458,27 @@ bool loadPreviousFitResult(RooWorkspace& myws, string FileName, string DSTAG, bo
   setFixedVarsToContantVars(myws);
   cout << printFun << endl;
 
+  if (updateN && myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))) {
+    string dsName = Form("dOS_%s_%s", DSTAG.c_str(), (isPbPb ?"PbPb":"PP"));
+    cout << "[INFO] Checking if local dataset is compatible with Mass fit dataset!" << endl;
+    if (myws.data(dsName.c_str()) && ws->data(dsName.c_str()) && !isCompatibleDataset(*(RooDataSet*)myws.data(dsName.c_str()), *(RooDataSet*)ws->data(dsName.c_str()), false)) {
+      // Let's fit again the mass with only the N parameters free, to account for possible ctau or ctauErr cuts in the input datasets
+      myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kTRUE);
+      std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"}; std::map< std::string , double > dN;
+      for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"))))  setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false); }
+      std::cout << "[INFO] Fitting the mass distribution to update the number of events!" << std::endl;
+      for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) dN[obj] = myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))->getVal(); }
+      ((RooFitResult*)myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->fitTo(*myws.data(dsName.c_str()), Extended(kTRUE), Range("MassWindow"), NumCPU(32), PrintLevel(-1), Save()))->Print("v");
+      for (auto obj : objs) {
+        if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) cout << "[INFO] Change in " << Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"))
+                                                                               << " : " << dN.at(obj) << " -> " 
+                                                                               << myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))->getVal()
+                                                                               << endl;
+      }
+      myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kFALSE);
+    }
+  }
+
   delete ws;
   file->Close(); delete file;
   return true;
@@ -440,6 +513,52 @@ bool loadCtauErrRange(string FileName, struct KinCuts& cut)
   delete ws;
   file->Close(); delete file;
   return true;
+};
+
+
+bool loadYields(RooWorkspace& myws, string FileName, string dsName, string pdfName)
+{
+  if (gSystem->AccessPathName(FileName.c_str())) {
+    cout << "[INFO] File " << FileName << " was not found!" << endl;
+    return false; // File was not found
+  }
+  TFile *file = new TFile(FileName.c_str());
+  if (!file) return false;
+  RooWorkspace *ws = (RooWorkspace*) file->Get("workspace");
+  if (!ws) {
+    cout << "[INFO] Workspace was not found in: " << FileName << endl;
+    file->Close(); delete file;
+    return false;
+  }
+
+  bool compDS = true;
+  if (ws->data(dsName.c_str()) && myws.data(dsName.c_str())) {
+    if (isCompatibleDataset(*(RooDataSet*)myws.data(dsName.c_str()), *(RooDataSet*)ws->data(dsName.c_str()))) {
+      bool isPbPb = true; if (FileName.find("_PP_")!=std::string::npos) isPbPb = false;
+      const RooArgSet *params = ws->getSnapshot(Form("%s_parIni", pdfName.c_str()));
+      std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"};
+      for (auto obj : objs) {
+        string name = Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"));
+        if (params->find(name.c_str()))  {
+          string par = Form("%s[ %.1f, %.1f, %.1f ]", name.c_str(), 
+                            ((RooRealVar*)params->find(name.c_str()))->getVal(), 
+                            ((RooRealVar*)params->find(name.c_str()))->getMin(), 
+                            ((RooRealVar*)params->find(name.c_str()))->getMax());
+          myws.factory(par.c_str());
+          myws.var(name.c_str())->setVal(((RooRealVar*)params->find(name.c_str()))->getVal());
+          myws.var(name.c_str())->setMin(((RooRealVar*)params->find(name.c_str()))->getMin());
+          myws.var(name.c_str())->setMax(((RooRealVar*)params->find(name.c_str()))->getMax());
+          cout << "[INFO] Yield loaded : " << par << endl;
+        }
+      }
+    }
+    else { cout << "[INFO] RooDatasets used to extract the Yields are not compatible!" << endl; compDS = false; }
+  }
+  else { cout << "[INFO] RooDatasets used to extract the Yields were not found!" << endl; compDS = false; }
+
+  delete ws;
+  file->Close(); delete file;
+  return compDS;
 };
 
 
@@ -524,20 +643,6 @@ int importDataset(RooWorkspace& myws, const RooWorkspace& inputWS, struct KinCut
     delete dataSS;
   }
 
-  if (myws.data(Form("dOS_%s_SPLOT_INPUT", label.c_str()))){
-    RooDataSet* dataOS = (RooDataSet*)myws.data(Form("dOS_%s_SPLOT_INPUT", label.c_str()))->reduce(strCut.c_str());
-    if (dataOS) {
-      if (dataOS->sumEntries()==0){ cout << "[ERROR] No events from dataset " <<  Form("dOS_%s_SPLOT_INPUT", label.c_str()) << " passed the kinematic cuts!" << endl; }
-      else if (dataOS->sumEntries()!=myws.data(Form("dOS_%s", label.c_str()))->sumEntries()){ cout << "[ERROR] Datasets are inconsistent!" << endl; }
-      else {
-        myws.import(*dataOS, Rename(Form("dOS_%s_SPLOT", label.c_str())));
-        if (myws.data(Form("dOS_%s_SPLOT", label.c_str()))) { cout << "[INFO] RooDataset " << Form("dOS_%s_SPLOT", label.c_str()) << " was imported!" << endl; }
-        else { cout << "[ERROR] Importing RooDataset " << Form("dOS_%s_SPLOT", label.c_str()) << " failed!" << endl; }
-      }
-      delete dataOS;
-    }
-  }
-
   // Set the range of each global parameter in the local roodataset
   const RooArgSet* rowOS = myws.data(Form("dOS_%s", label.c_str()))->get();
   ((RooRealVar*)rowOS->find("invMass"))->setMin(cut.dMuon.M.Min);        
@@ -564,6 +669,48 @@ int importDataset(RooWorkspace& myws, const RooWorkspace& inputWS, struct KinCut
     ((RooRealVar*)rowOS->find("ctauN"))->setMin(cut.dMuon.ctauN.Min);      
     ((RooRealVar*)rowOS->find("ctauN"))->setMax(cut.dMuon.ctauN.Max);
   }
+
+  if (myws.data(Form("dOS_%s_SPLOT_INPUT", label.c_str()))){
+    RooDataSet* dataOS = (RooDataSet*)myws.data(Form("dOS_%s_SPLOT_INPUT", label.c_str()))->reduce(strCut.c_str()); 
+    if (dataOS) {
+      // Set the range of each global parameter in the local roodataset
+      const RooArgSet* rowOS = dataOS->get();
+      ((RooRealVar*)rowOS->find("invMass"))->setMin(cut.dMuon.M.Min);        
+      ((RooRealVar*)rowOS->find("invMass"))->setMax(cut.dMuon.M.Max);
+      ((RooRealVar*)rowOS->find("pt"))->setMin(cut.dMuon.Pt.Min);            
+      ((RooRealVar*)rowOS->find("pt"))->setMax(cut.dMuon.Pt.Max);
+      ((RooRealVar*)rowOS->find("ctau"))->setMin(cut.dMuon.ctau.Min);        
+      ((RooRealVar*)rowOS->find("ctau"))->setMax(cut.dMuon.ctau.Max);
+      ((RooRealVar*)rowOS->find("ctauErr"))->setMin(cut.dMuon.ctauErr.Min);
+      ((RooRealVar*)rowOS->find("ctauErr"))->setMax(cut.dMuon.ctauErr.Max);
+      if (label.find("PbPb")!=std::string::npos){
+        ((RooRealVar*)rowOS->find("cent"))->setMin(cut.Centrality.Start);      
+        ((RooRealVar*)rowOS->find("cent"))->setMax(cut.Centrality.End);
+      }
+      if (label.find("MC")!=std::string::npos){
+        ((RooRealVar*)rowOS->find("ctauTrue"))->setMin(cut.dMuon.ctauTrue.Min);      
+        ((RooRealVar*)rowOS->find("ctauTrue"))->setMax(cut.dMuon.ctauTrue.Max);
+        ((RooRealVar*)rowOS->find("ctauRes"))->setMin(cut.dMuon.ctauRes.Min);      
+        ((RooRealVar*)rowOS->find("ctauRes"))->setMax(cut.dMuon.ctauRes.Max);
+        ((RooRealVar*)rowOS->find("ctauNRes"))->setMin(cut.dMuon.ctauNRes.Min);      
+        ((RooRealVar*)rowOS->find("ctauNRes"))->setMax(cut.dMuon.ctauNRes.Max);
+      }
+      else {
+        ((RooRealVar*)rowOS->find("ctauN"))->setMin(cut.dMuon.ctauN.Min);      
+        ((RooRealVar*)rowOS->find("ctauN"))->setMax(cut.dMuon.ctauN.Max);
+      }
+      if (dataOS->sumEntries()==0){ cout << "[ERROR] No events from dataset " <<  Form("dOS_%s_SPLOT_INPUT", label.c_str()) << " passed the kinematic cuts!" << endl; }
+      else if (!isCompatibleDataset(*dataOS, *(RooDataSet*)myws.data(Form("dOS_%s", label.c_str())))){ cout << "[ERROR] sPlot and Original Datasets are inconsistent!" << endl; delete dataOS; return -1; }
+      else {
+        myws.import(*dataOS, Rename(Form("dOS_%s_SPLOT", label.c_str())));
+        if (myws.data(Form("dOS_%s_SPLOT", label.c_str()))) { cout << "[INFO] RooDataset " << Form("dOS_%s_SPLOT", label.c_str()) << " was imported!" << endl; }
+        else { cout << "[ERROR] Importing RooDataset " << Form("dOS_%s_SPLOT", label.c_str()) << " failed!" << endl; delete dataOS; return -1; }
+        cout << "[INFO] SPlotDS Events: " << dataOS->sumEntries() << " , origDS Events: " << myws.data(Form("dOS_%s", label.c_str()))->sumEntries() << std::endl;
+      }
+      delete dataOS;
+    }
+  }
+
   // Set the range of each global parameter in the local workspace
   myws.var("invMass")->setMin(cut.dMuon.M.Min);        
   myws.var("invMass")->setMax(cut.dMuon.M.Max);
@@ -679,20 +826,6 @@ void getCtauErrRange(TH1* hist, int nMaxBins, vector<double>& rangeErr)
 };
 
 
-bool setConstant( RooWorkspace& myws, string parName, bool CONST)
-{
-  if (myws.var(parName.c_str())) { 
-    myws.var(parName.c_str())->setConstant(CONST);
-    if (CONST) { cout << "[INFO] Setting parameter " << parName << " : " << myws.var(parName.c_str())->getVal() << " to constant value!" << endl; }
-  }
-  else if (!myws.function(parName.c_str())) { 
-    cout << "[ERROR] Parameter " << parName << " was not found!" << endl;
-    return false;
-  }
-
-  return true;
-};
-
 bool isSPlotDSAlreadyFound(RooWorkspace& myws, string FileName, vector<string> dsNames, bool loadDS)
 {
   if (gSystem->AccessPathName(FileName.c_str())) {
@@ -767,5 +900,6 @@ bool isPdfAlreadyFound(RooWorkspace& myws, string FileName, vector<string> pdfNa
 
   return found;
 };
+
 
 #endif // #ifndef initClasses_h

--- a/HIN-16-004/Fitter/Macros/buildCharmoniaMassModel.C
+++ b/HIN-16-004/Fitter/Macros/buildCharmoniaMassModel.C
@@ -123,7 +123,10 @@ bool buildCharmoniaMassModel(RooWorkspace& ws, struct CharmModel model, map<stri
 bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, map<string,string> parIni, bool isPbPb) 
 {
   cout << Form("[INFO] Implementing %s Background Mass Model", object.c_str()) << endl;
-  
+
+  // Import the Yield parameter
+  if (!ws.var(Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")))) { ws.factory(parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()); }
+
   switch(model) 
     {  
     case (MassModel::Uniform): 
@@ -133,7 +136,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background Uniform PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -157,7 +160,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 1st Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -184,7 +187,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 2nd Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -214,7 +217,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 3rd Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -247,7 +250,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 4th Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -283,7 +286,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 5th Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -322,7 +325,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 6th Order Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -352,7 +355,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 1st Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -385,7 +388,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 2nd Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -421,7 +424,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 3rd Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -460,7 +463,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 4th Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -502,7 +505,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 5th Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -547,7 +550,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background 6th Order Exponential Chebychev PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -571,7 +574,7 @@ bool addBackgroundMassModel(RooWorkspace& ws, string object, MassModel model, ma
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Background Exponential PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -592,6 +595,9 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
   
   std::string lb = Form("_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"));
   RooAbsPdf* pdf = NULL;
+
+  // Import the Yield parameter
+  if (!ws.var(Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")))) { ws.factory(parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()); }
 
   switch(model) 
     {    
@@ -617,7 +623,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
     
       cout << Form("[INFO] %s Single Gaussian PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;  
@@ -659,7 +665,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Double Gaussian PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break; 
@@ -692,7 +698,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Single Crystal Ball PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -733,7 +739,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
       if (pdf) { ws.import(*pdf); }
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Extended Crystal Ball PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -787,7 +793,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Double Crystal Ball PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;
@@ -836,7 +842,7 @@ bool addSignalMassModel(RooWorkspace& ws, string object, MassModel model, map<st
 
       ws.factory(Form("RooExtendPdf::%s(%s,%s)", Form("pdfMASSTot_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
                       Form("pdfMASS_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP")),
-                      parIni[Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))].c_str()
+                      Form("N_%s_%s", object.c_str(), (isPbPb?"PbPb":"PP"))
                       ));
 
       cout << Form("[INFO] %s Gaussian and Crystal Ball PDF in %s included", object.c_str(), (isPbPb?"PbPb":"PP")) << endl; break;

--- a/HIN-16-004/Fitter/Macros/drawCtauFrom2DPlot.C
+++ b/HIN-16-004/Fitter/Macros/drawCtauFrom2DPlot.C
@@ -49,8 +49,8 @@ void drawCtauFrom2DPlot(RooWorkspace& myws,   // Local workspace
   bool isWeighted = myws.data(dsOSName.c_str())->isWeighted();
   vector<double> range; range.push_back(cut.dMuon.ctau.Min); range.push_back(cut.dMuon.ctau.Max);
 
-  double minRange = -3.0;
-  double maxRange = 5.0;
+  double minRange = -4.0;
+  double maxRange = 6.0;
   Double_t outTot = myws.data(dsOSName.c_str())->numEntries();
   Double_t outErr = myws.data(dsOSName.c_str())->reduce(Form("(ctau>%.6f || ctau<%.6f)", range[1], range[0]))->numEntries();
   int nBins = min(int( round((maxRange - minRange)/binWidth) ), 1000);

--- a/HIN-16-004/Fitter/Macros/drawCtauFrom2DPlot.C
+++ b/HIN-16-004/Fitter/Macros/drawCtauFrom2DPlot.C
@@ -50,7 +50,7 @@ void drawCtauFrom2DPlot(RooWorkspace& myws,   // Local workspace
   vector<double> range; range.push_back(cut.dMuon.ctau.Min); range.push_back(cut.dMuon.ctau.Max);
 
   double minRange = -4.0;
-  double maxRange = 6.0;
+  double maxRange = 7.0;
   Double_t outTot = myws.data(dsOSName.c_str())->numEntries();
   Double_t outErr = myws.data(dsOSName.c_str())->reduce(Form("(ctau>%.6f || ctau<%.6f)", range[1], range[0]))->numEntries();
   int nBins = min(int( round((maxRange - minRange)/binWidth) ), 1000);

--- a/HIN-16-004/Fitter/Macros/drawCtauPlot.C
+++ b/HIN-16-004/Fitter/Macros/drawCtauPlot.C
@@ -49,6 +49,8 @@ void drawCtauPlot(RooWorkspace& myws,   // Local workspace
   string dsOSNameCut = dsOSName+"_CTAUCUT";
   string dsOSName2Fit = dsOSName;
   if (useSPlot && incBkg) dsOSName2Fit += "_BKG";
+  else if (useSPlot && incJpsi) dsOSName2Fit += "_JPSI";
+  else if (useSPlot && incPsi2S) dsOSName2Fit += "_PSI2S";
   string dsOSName2FitCut = dsOSName2Fit+"_CTAUCUT";
   string hOSName = Form("dhCTAUERRTot_Tot_%s", (isPbPb?"PbPb":"PP"));
   string hOSNameBkg  = Form("dhCTAUERR_Bkg_%s", (isPbPb?"PbPb":"PP"));
@@ -121,66 +123,58 @@ void drawCtauPlot(RooWorkspace& myws,   // Local workspace
                                            );
     }
   }
-  if (!incBkg || (incJpsi || incPsi2S)) {
-    if (incPrompt) {
-      if (incJpsi) {
-        int COLOR[] = { kGreen+5, kRed+2, kBlue+3, kViolet-5};
-        for (int i=1; i<5; i++) {
-          if (myws.pdf(Form("pdfCTAURES%d_JpsiPR_%s", i,(isPbPb?"PbPb":"PP")))){
-            myws.pdf(pdfTotName.c_str())->plotOn(frame,Name(Form("PDFJPSI%d",i)),Components(RooArgSet(*myws.pdf(Form("pdfCTAURES%d_JpsiPR_%s", i, (isPbPb?"PbPb":"PP"))))),
-                                                 ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(dsOSName2FitCut.c_str()), kTRUE),
-                                                 Normalization(normDSTot, RooAbsReal::NumEvent),
-                                                 LineColor(COLOR[i-1]), Precision(1e-5), NumCPU(32)
-                                                 );
-          }
-        }
-        myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_JpsiPR_%s", (isPbPb?"PbPb":"PP"))))),
-                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(dsOSName2FitCut.c_str()), kTRUE),
-                                             Normalization(normDSTot, RooAbsReal::NumEvent),
-                                             LineColor(kBlack), Precision(1e-5), NumCPU(32)
-                                             );
+  if (useSPlot) {
+    if (incJpsi) {
+      myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("JPSI"),  Normalization(normJpsi, RooAbsReal::NumEvent), NumCPU(32),
+                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNameJpsi.c_str()), kTRUE),
+                                           FillStyle(1001), FillColor(kAzure-9), VLines(), DrawOption("LCF"), Precision(1e-4)
+                                           );
+      myws.data(dsOSName2Fit.c_str())->plotOn(frame, Name("dOS"), DataError(RooAbsData::SumW2), XErrorSize(0), MarkerColor(kBlack), LineColor(kBlack), MarkerSize(1.2));
+      if (myws.pdf(Form("pdfCTAU_JpsiPR_%s", (isPbPb?"PbPb":"PP")))) {myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("JPSIPR"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_JpsiPR_%s", (isPbPb?"PbPb":"PP"))))),
+                                                                                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNameJpsi.c_str()), kTRUE),
+                                                                                                           Normalization(normJpsi, RooAbsReal::NumEvent),
+                                                                                                           LineColor(kRed+2), Precision(1e-4), NumCPU(32)
+                                                                                                           );
       }
-      if (incPsi2S) {
-        int COLOR[] = { kGreen+5, kRed+2, kBlue+3, kViolet-5};
-        for (int i=1; i<5; i++) {
-          if (myws.pdf(Form("pdfCTAURES%d_Psi2SPR_%s", i,(isPbPb?"PbPb":"PP")))){
-            myws.pdf(pdfTotName.c_str())->plotOn(frame,Name(Form("PDFPSI2S%d",i)),Components(RooArgSet(*myws.pdf(Form("pdfCTAURES%d_Psi2SPR_%s", i, (isPbPb?"PbPb":"PP"))))),
-                                                 ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(dsOSName2FitCut.c_str()), kTRUE),
-                                                 Normalization(normDSTot, RooAbsReal::NumEvent),
-                                                 LineColor(COLOR[i-1]), Precision(1e-5), NumCPU(32)
-                                                 );
-          }
-        }
-        myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_Psi2SPR_%s", (isPbPb?"PbPb":"PP"))))),
-                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(dsOSName2FitCut.c_str()), kTRUE),
-                                             Normalization(normDSTot, RooAbsReal::NumEvent),
-                                             LineColor(kBlack), Precision(1e-5), NumCPU(32)
-                                             );
+      if (myws.pdf(Form("pdfCTAU_JpsiNoPR_%s", (isPbPb?"PbPb":"PP")))) {myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("BKGNoPR"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_JpsiNoPR_%s", (isPbPb?"PbPb":"PP"))))),
+                                                                                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNameJpsi.c_str()), kTRUE),
+                                                                                                             Normalization(normJpsi, RooAbsReal::NumEvent),
+                                                                                                             LineColor(kOrange+10), Precision(1e-4), NumCPU(32)
+                                                                                                             );
       }
+      myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),  Normalization(normJpsi, RooAbsReal::NumEvent), NumCPU(32),
+                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNameJpsi.c_str()), kTRUE),
+                                           LineColor(kBlack), Precision(1e-4)
+                                           );
     }
-    if (incNonPrompt) {
-      if (incJpsi) {
-        myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_JpsiNoPR_%s", (isPbPb?"PbPb":"PP"))))),
-                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNameJpsi.c_str()), kTRUE),
-                                             Normalization(normJpsi, RooAbsReal::NumEvent),
-                                             LineColor(kBlack), Precision(1e-5), NumCPU(32)
-                                             );
+    if (incPsi2S) {
+      myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PSI2S"),  Normalization(normPsi2S, RooAbsReal::NumEvent), NumCPU(32),
+                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNamePsi2S.c_str()), kTRUE),
+                                           FillStyle(1001), FillColor(kAzure-9), VLines(), DrawOption("LCF"), Precision(1e-4)
+                                           );
+      myws.data(dsOSName2Fit.c_str())->plotOn(frame, Name("dOS"), DataError(RooAbsData::SumW2), XErrorSize(0), MarkerColor(kBlack), LineColor(kBlack), MarkerSize(1.2));
+      if (myws.pdf(Form("pdfCTAU_Psi2SPR_%s", (isPbPb?"PbPb":"PP")))) {myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("JPSIPR"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_Psi2SPR_%s", (isPbPb?"PbPb":"PP"))))),
+                                                                                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNamePsi2S.c_str()), kTRUE),
+                                                                                                           Normalization(normPsi2S, RooAbsReal::NumEvent),
+                                                                                                           LineColor(kRed+2), Precision(1e-4), NumCPU(32)
+                                                                                                           );
       }
-      if (incPsi2S) {
-        myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_Psi2SNoPR_%s", (isPbPb?"PbPb":"PP"))))),
-                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNamePsi2S.c_str()), kTRUE),
-                                             ProjWData(*myws.data(hOSNamePsi2S.c_str())), 
-                                             Normalization(normPsi2S, RooAbsReal::NumEvent),
-                                             LineColor(kBlack), Precision(1e-5), NumCPU(32)
-                                             );
+      if (myws.pdf(Form("pdfCTAU_Psi2SNoPR_%s", (isPbPb?"PbPb":"PP")))) {myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("BKGNoPR"),Components(RooArgSet(*myws.pdf(Form("pdfCTAU_Psi2SNoPR_%s", (isPbPb?"PbPb":"PP"))))),
+                                                                                                             ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNamePsi2S.c_str()), kTRUE),
+                                                                                                             Normalization(normPsi2S, RooAbsReal::NumEvent),
+                                                                                                             LineColor(kOrange+10), Precision(1e-4), NumCPU(32)
+                                                                                                             );
       }
-    } 
+      myws.pdf(pdfTotName.c_str())->plotOn(frame,Name("PDF"),  Normalization(normPsi2S, RooAbsReal::NumEvent), NumCPU(32),
+                                           ProjWData(RooArgSet(*myws.var("ctauErr")), *myws.data(hOSNamePsi2S.c_str()), kTRUE),
+                                           LineColor(kBlack), Precision(1e-4)
+                                           );
+    }
   }
   if (incSS) { 
     myws.data(dsSSName.c_str())->plotOn(frame, Name("dSS"), MarkerColor(kRed), LineColor(kRed), MarkerSize(1.2)); 
   }
   myws.data(dsOSName2Fit.c_str())->plotOn(frame, Name("dOS"), DataError(RooAbsData::SumW2), XErrorSize(0), MarkerColor(kBlack), LineColor(kBlack), MarkerSize(1.2));
-  
   
   // set the CMS style
   setTDRStyle();
@@ -259,8 +253,6 @@ void drawCtauPlot(RooWorkspace& myws,   // Local workspace
 
   // Drawing the Legend
   double ymin = 0.7802;
-  if (incPsi2S && incJpsi && incSS)  { ymin = 0.7202; } 
-  if (incPsi2S && incJpsi && !incSS) { ymin = 0.7452; }
   TLegend* leg = new TLegend(0.5175, ymin, 0.7180, 0.8809); leg->SetTextSize(0.03);
   leg->AddEntry(frame->findObject("dOS"), (incSS?"Opposite Charge":"Data"),"pe");
   if (incSS) { leg->AddEntry(frame->findObject("dSS"),"Same Charge","pe"); }
@@ -268,9 +260,6 @@ void drawCtauPlot(RooWorkspace& myws,   // Local workspace
   if((incBkg && (incJpsi || incPsi2S)) && frame->findObject("BKG")) { leg->AddEntry(frame->findObject("BKG"),"Background","fl");  }
   if(incBkg && incJpsi && frame->findObject("JPSI")) { leg->AddEntry(frame->findObject("JPSI"),"J/#psi PDF","l"); }
   if(incBkg && incPsi2S && frame->findObject("PSI2S")) { leg->AddEntry(frame->findObject("PSI2S"),"#psi(2S) PDF","l"); }
-  for (int i=1; i<5; i++) {
-    if(incJpsi && frame->findObject(Form("PDFJPSI%d",i))) { leg->AddEntry(frame->findObject(Form("PDFJPSI%d",i)),Form("PR Gauss %d", i),"l"); }
-  }
   leg->Draw("same");
 
   //Drawing the title

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
@@ -165,7 +165,7 @@ void setCtauErrGlobalParameterRange(RooWorkspace& myws, map<string, string>& par
     ctauErrMin -= 0.0001;  ctauErrMax += 0.0001;
     int nBins = min(int( round((ctauErrMax - ctauErrMin)/binWidth) ), 1000);
     TH1D* hTot = (TH1D*)myws.data(Form("dOS_%s", label.c_str()))->createHistogram("TMP", *myws.var("ctauErr"), Binning(nBins, ctauErrMin, ctauErrMax));
-    vector<double> rangeErr; getCtauErrRange(hTot, (int)(ceil(2)), rangeErr); // KEEP THIS NUMBER WITH 2, JUST KEEP IT LIKE THAT :D
+    vector<double> rangeErr; getRange(hTot, (int)(ceil(2)), rangeErr); // KEEP THIS NUMBER WITH 2, JUST KEEP IT LIKE THAT :D
     hTot->Delete();
     ctauErrMin = rangeErr[0];
     ctauErrMax = rangeErr[1];

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
@@ -130,9 +130,11 @@ bool fitCharmoniaCtauErrModel( RooWorkspace& myws,             // Local Workspac
       cout << "[INFO] Setting mass parameters to constant!" << endl;
       myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kTRUE); 
     } else { cout << "[ERROR] Mass PDF was not found!" << endl; return false; }
-    if (myws.pdf(Form("pdfMASS_Bkg_%s", (isPbPb?"PbPb":"PP"))))   { reNormMassVar(myws, "Bkg", isPbPb);   }
-    if (myws.pdf(Form("pdfMASS_Jpsi_%s", (isPbPb?"PbPb":"PP"))))  { reNormMassVar(myws, "Jpsi", isPbPb);  }
-    if (myws.pdf(Form("pdfMASS_Psi2S_%s", (isPbPb?"PbPb":"PP")))) { reNormMassVar(myws, "Psi2S", isPbPb); }
+    std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"}; std::map< std::string , double > dN;
+    // Let's fit again the mass with only the N parameters free, to account for possible ctau or ctauErr cuts in the input datasets
+    for (auto obj : objs) {
+      if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false);
+    }
   }
 
   if (skipCtauErrPdf==false) {
@@ -213,17 +215,5 @@ void setCtauErrCutParameters(struct KinCuts& cut)
   return;
 };
 
-
-void reNormMassVar( RooWorkspace& myws, string obj, bool isPbPb)
-{
-  string pdfName = Form("pdfMASS_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"));
-  string varName = Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"));
-  if (obj=="Bkg") { ((RooChebychev*)myws.pdf(pdfName.c_str()))->selectNormalizationRange("InclusiveMassRange", kTRUE); }
-  double NormFactor = 1.0/(myws.pdf(pdfName.c_str())->createIntegral(*myws.var("invMass"), NormSet(*myws.var("invMass")), Range("InclusiveMassRange"))->getValV());
-  myws.var(varName.c_str())->setVal(myws.var(varName.c_str())->getValV());
-  if (myws.var(varName.c_str())) { myws.var(varName.c_str())->setConstant(kFALSE); }
-  //cout << "[INFO] NORM FACTOR FOR " << obj << " : " << NormFactor << endl;
-  return;
-};
 
 #endif // #ifndef fitCharmoniaCtauErrModel_C

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauErrModel.C
@@ -126,15 +126,13 @@ bool fitCharmoniaCtauErrModel( RooWorkspace& myws,             // Local Workspac
                                  setLogScale, incSS, zoomPsi, ibWidth, getMeanPT
                                  ) 
          ) { return false; }
+    // Let's set all mass parameters to constant except the yields
     if (myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))) {
       cout << "[INFO] Setting mass parameters to constant!" << endl;
       myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kTRUE); 
     } else { cout << "[ERROR] Mass PDF was not found!" << endl; return false; }
-    std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"}; std::map< std::string , double > dN;
-    // Let's fit again the mass with only the N parameters free, to account for possible ctau or ctauErr cuts in the input datasets
-    for (auto obj : objs) {
-      if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false);
-    }
+    std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"};
+    for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false); }
   }
 
   if (skipCtauErrPdf==false) {

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauMassModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauMassModel.C
@@ -133,6 +133,8 @@ bool fitCharmoniaCtauMassModel( RooWorkspace& myws,             // Local Workspa
     } else { cout << "[ERROR] Mass PDF was not found!" << endl; return false; }
     std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"};
     for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"))))  setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false); }
+    // Let's set the minimum value of the yields to zero
+    for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))->setMin(0.0); }
     // Let's constrain the Number of Signal events to the updated mass fit results
     RooArgSet pdfList = RooArgSet("ConstrainPdfList");
     for (auto obj : objs) {

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauMassModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauMassModel.C
@@ -126,19 +126,13 @@ bool fitCharmoniaCtauMassModel( RooWorkspace& myws,             // Local Workspa
                                  setLogScale, incSS, zoomPsi, ibWidth, getMeanPT
                                  ) 
          ) { return false; }
-    // Let's set all mass parameters to constant except the Number of Events
+    // Let's set all mass parameters to constant except the yields
     if (myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))) {
       cout << "[INFO] Setting mass parameters to constant!" << endl;
       myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kTRUE); 
     } else { cout << "[ERROR] Mass PDF was not found!" << endl; return false; }
     std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"};
-    // Let's fit again the mass with only the N parameters free, to account for possible ctau or ctauErr cuts in the input datasets
-    for (auto obj : objs) {
-      if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"))))  setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false);
-    }
-    std::cout << "[INFO] Fitting the mass distribution to update the number of events!" << std::endl;
-    RooFitResult* fitResult = myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->fitTo(*myws.data(dsNameCut.c_str()), Extended(kTRUE), Range("MassWindow"), NumCPU(numCores), PrintLevel(-1), Save());
-    fitResult->Print("v");
+    for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP"))))  setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false); }
     // Let's constrain the Number of Signal events to the updated mass fit results
     RooArgSet pdfList = RooArgSet("ConstrainPdfList");
     for (auto obj : objs) {
@@ -248,7 +242,8 @@ bool fitCharmoniaCtauMassModel( RooWorkspace& myws,             // Local Workspa
     string FileName = "";
     string plotLabel = Form("_CtauRes_%s", parIni[Form("Model_CtauRes_%s", COLL.c_str())].c_str());
     string DSTAG = Form("MCJPSIPR_%s", (isPbPb?"PbPb":"PP"));
-    if (inputFitDir["CTAURES"].find("NP")!=std::string::npos) DSTAG = Form("MCJPSINOPR_%s", (isPbPb?"PbPb":"PP")); 
+    if (inputFitDir["CTAURES"].find("nonPrompt")!=std::string::npos) DSTAG = Form("MCJPSINOPR_%s", (isPbPb?"PbPb":"PP"));
+    if (inputFitDir["CTAURES"].find("DataFits")!=std::string::npos) DSTAG = Form("DATA_%s", (isPbPb?"PbPb":"PP"));
     setCtauResFileName(FileName, (inputFitDir["CTAURES"]=="" ? outputDir : inputFitDir["CTAURES"]), DSTAG, plotLabel, cut, isPbPb);
     if (wantPureSMC) { plotLabel = plotLabel + "_NoBkg"; }
     bool found = false;

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauModel.C
@@ -259,7 +259,7 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
         cout << "[ERROR] User Input File : " << FileName << " was not found!" << endl;
         return false;
       }
-      if ( !loadPreviousFitResult(myws, FileName, DSTAG, isPbPb) ) {
+      if ( !loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, false, false) ) {
         cout << "[ERROR] The ctau resolution fit results were not loaded!" << endl;
         return false;
       } else { 
@@ -284,7 +284,7 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
   {
     found = found && isFitAlreadyFound(newpars, FileName, pdfName.c_str());
     if (loadFitResult) {
-      if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb) ) { skipFit = true; } else  { skipFit = false; }
+      if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, false, false) ) { skipFit = true; } else  { skipFit = false; }
       if (skipFit) { cout << "[INFO] This ctau fit was already done, so I'll load the fit results." << endl; }
       myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()),*newpars,kTRUE);
     } else if (found) {
@@ -477,7 +477,7 @@ void setCtauGlobalParameterRange(RooWorkspace& myws, map<string, string>& parIni
   if (fitCtauRes) {
     TH1D* hTot = (TH1D*)myws.data(Form("dOS_%s", label.c_str()))->createHistogram("TMP", *myws.var("ctau"), Binning(nBins, ctauMin, ctauMax));
     vector<double> rangeCtau; 
-    getCtauErrRange(hTot, (int)(ceil(2)), rangeCtau);
+    getRange(hTot, (int)(ceil(2)), rangeCtau);
     hTot->Delete();
     ctauMin = rangeCtau[0];
     ctauMax = rangeCtau[1];

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauModel.C
@@ -13,7 +13,7 @@ void setCtauFileName(string& FileName, string outputDir, string TAG, string plot
 void setCtauGlobalParameterRange(RooWorkspace& myws, map<string, string>& parIni, struct KinCuts& cut, string label, double binWidth, bool fitCtauRes=false);
 void setCtauCutParameters(struct KinCuts& cut, bool incNonPrompt);
 bool isCtauBkgPdfAlreadyFound(RooWorkspace& myws, string FileName, string pdfName, bool loadCtauBkgPdf=false);
-bool createBkgCtauDSUsingSPLOT(RooWorkspace& ws, string dsName, map<string, string> parIni, struct KinCuts cut);
+bool createCtauDSUsingSPLOT(RooWorkspace& ws, string dsName, map<string, string>  parIni, struct KinCuts cut, bool incJpsi, bool incPsi2S, bool incBkg);
 
 
 bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
@@ -61,11 +61,11 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
     isMC = true;
   }
   if (!isMC) { wantPureSMC=false; }
+  if (useSPlot && ((incBkg&&incJpsi)||(incBkg&&incPsi2S)||(incPsi2S&&incJpsi))) { cout << "[ERROR] Only one object can be fitted using sPlot!" << endl; return false; }
   bool fitSideBand = (incBkg && (!incPsi2S && !incJpsi));
 
   string COLL = (isPbPb ? "PbPb" : "PP" );
   string fitType = "CTAU";
-  if (isMC && incPrompt && !incNonPrompt) { fitType = "CTAURES"; }
   if (!isMC && fitSideBand) { fitType = "CTAUSB";  }
   string label = ((DSTAG.find(COLL.c_str())!=std::string::npos) ? DSTAG.c_str() : Form("%s_%s", DSTAG.c_str(), COLL.c_str()));
 
@@ -110,11 +110,13 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
   if (importDS) { 
     // Set global parameters
     setCtauErrGlobalParameterRange(myws, parIni, cut, "", binWidth["CTAUERR"], true);
-    setCtauGlobalParameterRange(myws, parIni, cut, label, binWidth[fitType.c_str()], (fitType=="CTAURES"));
+    setCtauGlobalParameterRange(myws, parIni, cut, label, binWidth[fitType.c_str()], (!incBkg&&useSPlot&&!isPbPb));
   }
 
   string dsName2Fit = dsName;
   if (useSPlot && incBkg) dsName2Fit += "_BKG";
+  else if (useSPlot && incJpsi) dsName2Fit += "_JPSI";
+  else if (useSPlot && incPsi2S) dsName2Fit += "_PSI2S";
   string dsName2FitCut = dsName2Fit+"_CTAUCUT";
 
   string plotLabel = "";
@@ -159,7 +161,7 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
   if (useSPlot) {
     // Check if we have already made the Background DataSet
     vector<string> dsNames = { dsName2Fit };
-    bool createBkgDS = ( !isSPlotDSAlreadyFound(myws, FileName, dsNames, true) );
+    bool createSPLOTDS = ( !isSPlotDSAlreadyFound(myws, FileName, dsNames, true) );
     bool compDS = loadYields(myws, FileName, dsName, pdfName);
     if (!compDS && (incJpsi || incPsi2S || incBkg)) {
       // Setting extra input information needed by each fitter
@@ -192,15 +194,19 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
       // Let's set the minimum value of the yields to zero
       for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))->setMin(0.0); }
     }
-    if (createBkgDS) {
+    if (createSPLOTDS) {
       if (importDS && !myws.data(dsName2Fit.c_str())) {
-        if (!createBkgCtauDSUsingSPLOT(myws, dsName, parIni, cut)){ cout << "[ERROR] Creating the Bkg Ctau Templates using sPLOT failed" << endl; return false; }
+        if (!createCtauDSUsingSPLOT(myws, dsName, parIni, cut, incJpsi, incPsi2S, incBkg)){ cout << "[ERROR] Creating the Ctau Templates using sPLOT failed" << endl; return false; }
       }
     }
   }
   if (importDS && !myws.data(dsName2FitCut.c_str())) {
+    // Cut the RooDataSet
     RooDataSet* dataToFit = (RooDataSet*)(myws.data(dsName2Fit.c_str())->reduce(parIni["CtauRange_Cut"].c_str()))->Clone(dsName2FitCut.c_str());
     myws.import(*dataToFit, Rename(dsName2FitCut.c_str()));
+    double lostEvents = (myws.data(dsName2Fit.c_str())->numEntries()-myws.data(dsName2FitCut.c_str())->numEntries());
+    double lostPerc = lostEvents*100./(myws.data(dsName2Fit.c_str())->numEntries());
+    cout << "[INFO] After applying the cut: " << parIni["CtauRange_Cut"] << " , we lost " << lostEvents << " events ( " << lostPerc << " % ) " << endl;
   }
   
   if (!loadFitResult) {
@@ -233,7 +239,7 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
     if (!buildCharmoniaCtauModel(myws, (isPbPb ? model.PbPb : model.PP), parIni, dsName2FitCut, cut, isPbPb, incBkg, incJpsi, incPsi2S, incPrompt, incNonPrompt, useTotctauErrPdf, usectauBkgTemplate, binWidth["CTAUSB"], numEntries))  { return false; }
 
     //// LOAD CTAU RESOLUTION PDF
-    if (fitSideBand && !usectauBkgTemplate) {
+    if ((fitSideBand || useSPlot) && !usectauBkgTemplate) {
       // check if we have already done the resolution fits. If yes, load their results
       string FileName = "";
       string plotLabel = Form("_CtauRes_%s", parIni[Form("Model_CtauRes_%s", COLL.c_str())].c_str());
@@ -265,10 +271,14 @@ bool fitCharmoniaCtauModel( RooWorkspace& myws,             // Local Workspace
       } else { 
         cout << "[INFO] The ctau resolution fits were found, so I'll load the fit results." << endl; 
       }
-      if (myws.pdf(Form("pdfCTAU_BkgPR_%s", (isPbPb?"PbPb":"PP")))) {
-        cout << "[INFO] Setting Prompt Background parameters to constant!" << endl;
-        myws.pdf(Form("pdfCTAU_BkgPR_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("ctau"), *myws.var("ctauErr")))->setAttribAll("Constant", kTRUE); 
-      } else { cout << "[ERROR] Prompt Background PDF was not found!" << endl; return false; }
+      std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"}; bool hasPromptPdf = false;
+      for (auto obj : objs) {
+        if (myws.pdf(Form("pdfCTAU_%sPR_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) {
+          cout << "[INFO] Setting Prompt " << obj << " parameters to constant!" << endl; hasPromptPdf = true;
+          myws.pdf(Form("pdfCTAU_%sPR_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("ctau"), *myws.var("ctauErr")))->setAttribAll("Constant", kTRUE); 
+        }
+      }
+      if (!hasPromptPdf) { cout << "[ERROR] Prompt Ctau PDF was not found!" << endl; return false; }
       if (!setConstant(myws, Form("s1_CtauRes_%s", COLL.c_str()), true)) { return false; }
     }
 
@@ -468,33 +478,22 @@ bool setCtauModel( struct OniaModel& model, map<string, string>&  parIni, bool i
 };
 
 
-void setCtauGlobalParameterRange(RooWorkspace& myws, map<string, string>& parIni, struct KinCuts& cut, string label, double binWidth, bool fitCtauRes)
+void setCtauGlobalParameterRange(RooWorkspace& myws, map<string, string>& parIni, struct KinCuts& cut, string label, double binWidth, bool optimizeRange)
 {
   Double_t ctauMax; Double_t ctauMin;
   myws.data(Form("dOS_%s", label.c_str()))->getRange(*myws.var("ctau"), ctauMin, ctauMax);
   ctauMin -= 0.00001;  ctauMax += 0.00001;
   int nBins = min(int( round((ctauMax - ctauMin)/binWidth) ), 1000);
-  if (fitCtauRes) {
-    TH1D* hTot = (TH1D*)myws.data(Form("dOS_%s", label.c_str()))->createHistogram("TMP", *myws.var("ctau"), Binning(nBins, ctauMin, ctauMax));
+  if (optimizeRange) {
+    TH1D* hTot = (TH1D*)((RooDataSet*)myws.data(Form("dOS_%s", label.c_str()))->Clone("dTMP"))->createHistogram("hTMP", *myws.var("ctau"), Binning(nBins, ctauMin, ctauMax));
     vector<double> rangeCtau; 
-    getRange(hTot, (int)(ceil(2)), rangeCtau);
+    getRange(hTot, 4, rangeCtau);
     hTot->Delete();
     ctauMin = rangeCtau[0];
-    ctauMax = rangeCtau[1];
-    if (abs(ctauMax)>abs(ctauMin)) { ctauMax = abs(ctauMin); } else { ctauMin = -1.0*abs(ctauMax); }
     if (ctauMin<cut.dMuon.ctau.Min) { ctauMin = cut.dMuon.ctau.Min; }
     if (ctauMax>cut.dMuon.ctau.Max) { ctauMax = cut.dMuon.ctau.Max; }
-    if (parIni.count("ctauResCut")>0 && parIni["ctauResCut"]!="") {
-      parIni["ctauResCut"].erase(parIni["ctauResCut"].find("["), string("[").length());
-      parIni["ctauResCut"].erase(parIni["ctauResCut"].find("]"), string("]").length());
-      double ctauCut = 0.0;
-      try {
-        ctauCut = std::stod(parIni["ctauResCut"].c_str());
-      } catch (const std::invalid_argument&) {
-        cout << "[WARNING] ctauResCut is not a number, will ignore it!" << endl;
-      }
-      ctauCut = abs(ctauCut); if(ctauCut>0.0) { ctauMax = abs(ctauCut); ctauMin = -1.0*abs(ctauCut); }
-    }
+    if (ctauMin < -4.0) { ctauMin = -4.0; }
+    ctauMax =  7.0;
   }
   cout << "[INFO] Range from data: ctauMin: " << ctauMin << "  ctauMax: " << ctauMax << endl;
   myws.var("ctau")->setRange("CtauWindow", ctauMin, ctauMax);
@@ -532,7 +531,7 @@ void setCtauCutParameters(struct KinCuts& cut, bool incNonPrompt)
   if (cut.dMuon.ctau.Min==-1000. && cut.dMuon.ctau.Max==1000.) { 
     // Default ctau values, means that the user did not specify a ctau range
     if (incNonPrompt) {
-      cut.dMuon.ctau.Min = -50.0;
+      cut.dMuon.ctau.Min = -30.0;
       cut.dMuon.ctau.Max = 100.0;
     } else {
       cut.dMuon.ctau.Min = -2.0;
@@ -546,7 +545,7 @@ void setCtauCutParameters(struct KinCuts& cut, bool incNonPrompt)
 };
 
 
-bool createBkgCtauDSUsingSPLOT(RooWorkspace& ws, string dsName, map<string, string>  parIni, struct KinCuts cut)
+bool createCtauDSUsingSPLOT(RooWorkspace& ws, string dsName, map<string, string>  parIni, struct KinCuts cut, bool incJpsi, bool incPsi2S, bool incBkg)
 {  
   bool isPbPb = false;
   if (dsName.find("PbPb")!=std::string::npos) { isPbPb = true; }
@@ -566,10 +565,24 @@ bool createBkgCtauDSUsingSPLOT(RooWorkspace& ws, string dsName, map<string, stri
     delete data; delete pdf;
   }
   
-  RooDataSet* dataw_Bkg  = new RooDataSet("TMP_BKG_DATA","TMP_BKG_DATA", (RooDataSet*)ws.data((dsName+"_SPLOT").c_str()), RooArgSet(*ws.var("invMass"), *ws.var("ctau"), *ws.var("ctauN"), *ws.var("ctauErr"), *ws.var(Form("N_Bkg_%s_sw", (isPbPb?"PbPb":"PP")))), 0, Form("N_Bkg_%s_sw", (isPbPb?"PbPb":"PP")));
-  ws.import(*dataw_Bkg, Rename((dsName+"_BKG").c_str()));
-  cout <<  "[INFO] sPLOT_BKG_DS Events: " << ws.data((dsName+"_BKG").c_str())->sumEntries() << std::endl;
-  delete dataw_Bkg;
+  if (incBkg) {
+    RooDataSet* dataw_Bkg  = new RooDataSet("TMP_BKG_DATA","TMP_BKG_DATA", (RooDataSet*)ws.data((dsName+"_SPLOT").c_str()), RooArgSet(*ws.var("invMass"), *ws.var("ctau"), *ws.var("ctauN"), *ws.var("ctauErr"), *ws.var(Form("N_Bkg_%s_sw", (isPbPb?"PbPb":"PP")))), 0, Form("N_Bkg_%s_sw", (isPbPb?"PbPb":"PP")));
+    ws.import(*dataw_Bkg, Rename((dsName+"_BKG").c_str()));
+    cout <<  "[INFO] sPLOT_BKG_DS Events: " << ws.data((dsName+"_BKG").c_str())->sumEntries() << std::endl;
+    delete dataw_Bkg;
+  }
+  if (incJpsi) {
+    RooDataSet* dataw_Sig  = new RooDataSet("TMP_JPSI_DATA","TMP_JPSI_DATA", (RooDataSet*)ws.data((dsName+"_SPLOT").c_str()), RooArgSet(*ws.var("invMass"), *ws.var("ctau"), *ws.var("ctauN"), *ws.var("ctauErr"), *ws.var(Form("N_Jpsi_%s_sw", (isPbPb?"PbPb":"PP")))), 0, Form("N_Jpsi_%s_sw", (isPbPb?"PbPb":"PP")));
+    ws.import(*dataw_Sig, Rename((dsName+"_JPSI").c_str()));
+    cout <<  "[INFO] sPLOT_JPSI_DS Events: " << ws.data((dsName+"_JPSI").c_str())->sumEntries() << std::endl;
+    delete dataw_Sig;
+  }
+  if (incPsi2S) {
+    RooDataSet* dataw_Sig  = new RooDataSet("TMP_PSI2S_DATA","TMP_PSI2S_DATA", (RooDataSet*)ws.data((dsName+"_SPLOT").c_str()), RooArgSet(*ws.var("invMass"), *ws.var("ctau"), *ws.var("ctauN"), *ws.var("ctauErr"), *ws.var(Form("N_Psi2S_%s_sw", (isPbPb?"PbPb":"PP")))), 0, Form("N_Psi2S_%s_sw", (isPbPb?"PbPb":"PP")));
+    ws.import(*dataw_Sig, Rename((dsName+"_PSI2S").c_str()));
+    cout <<  "[INFO] sPLOT_PSI2S_DS Events: " << ws.data((dsName+"_PSI2S").c_str())->sumEntries() << std::endl;
+    delete dataw_Sig;
+  }
   
   return true;
 };

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResDataModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResDataModel.C
@@ -134,13 +134,13 @@ bool fitCharmoniaCtauResDataModel( RooWorkspace& myws,             // Local Work
                                  setLogScale, incSS, zoomPsi, ibWidth, getMeanPT
                                  )
          ) { return false; }
+    // Let's set all mass parameters to constant except the yields
     if (myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))) {
       cout << "[INFO] Setting mass parameters to constant!" << endl;
       myws.pdf(Form("pdfMASS_Tot_%s", (isPbPb?"PbPb":"PP")))->getParameters(RooArgSet(*myws.var("invMass")))->setAttribAll("Constant", kTRUE);
     } else { cout << "[ERROR] Mass PDF was not found!" << endl; return false; }
-    if (myws.pdf(Form("pdfMASS_Bkg_%s", (isPbPb?"PbPb":"PP"))))   { setConstant( myws, Form("N_Bkg_%s", (isPbPb?"PbPb":"PP")), false);   }
-    if (myws.pdf(Form("pdfMASS_Jpsi_%s", (isPbPb?"PbPb":"PP"))))  { setConstant( myws, Form("N_Jpsi_%s", (isPbPb?"PbPb":"PP")), false);  }
-    if (myws.pdf(Form("pdfMASS_Psi2S_%s", (isPbPb?"PbPb":"PP")))) { setConstant( myws, Form("N_Psi2S_%s", (isPbPb?"PbPb":"PP")), false); }
+    std::vector< std::string > objs = {"Bkg", "Jpsi", "Psi2S"};
+    for (auto obj : objs) { if (myws.var(Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")))) setConstant( myws, Form("N_%s_%s", obj.c_str(), (isPbPb?"PbPb":"PP")), false); }
   }
 
   if (createSignalDS) {  

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResDataModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResDataModel.C
@@ -202,7 +202,7 @@ bool fitCharmoniaCtauResDataModel( RooWorkspace& myws,             // Local Work
   RooArgSet *newpars = myws.pdf(pdfName.c_str())->getParameters(RooArgSet(*myws.var("ctau"), *myws.var("ctauErr"), *myws.var("ctauN")));
   found = found && isFitAlreadyFound(newpars, FileName, pdfName.c_str());
   if (loadFitResult) {
-    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb) ) { skipFit = true; } else  { skipFit = false; }
+    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, false, false) ) { skipFit = true; } else  { skipFit = false; }
     if (skipFit) { cout << "[INFO] This ctau fit was already done, so I'll load the fit results." << endl; }
     myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()),*newpars,kTRUE);
   } else if (found) {
@@ -264,7 +264,7 @@ void setCtauResDataGlobalParameterRange(RooWorkspace& myws, map<string, string>&
   int nBins = min(int( round((ctauNMax - ctauNMin)/binWidth) ), 1000);
   TH1D* hTot = (TH1D*)myws.data(dsName.c_str())->createHistogram("TMP", *myws.var("ctauN"), Binning(nBins, ctauNMin, ctauNMax));
   vector<double> rangeCtauN;
-  getCtauErrRange(hTot, (int)(ceil(3)), rangeCtauN);
+  getRange(hTot, (int)(ceil(3)), rangeCtauN);
   hTot->Delete();
   ctauNMin = rangeCtauN[0];
   if (ctauNMin<-10.0){ ctauNMin = -10.0; }

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResModel.C
@@ -151,7 +151,7 @@ bool fitCharmoniaCtauResModel( RooWorkspace& myws,             // Local Workspac
   RooArgSet *newpars = myws.pdf(pdfName.c_str())->getParameters(RooArgSet(*myws.var("ctau"), *myws.var("ctauErr"), *myws.var("ctauNRes"), *myws.var("ctauRes")));
   found = found && isFitAlreadyFound(newpars, FileName, pdfName.c_str());
   if (loadFitResult) {
-    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb) ) { skipFit = true; } else  { skipFit = false; }
+    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, false, false) ) { skipFit = true; } else  { skipFit = false; }
     if (skipFit) { cout << "[INFO] This ctau fit was already done, so I'll load the fit results." << endl; }
     myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()),*newpars,kTRUE);
   } else if (found) {
@@ -212,7 +212,7 @@ void setCtauResGlobalParameterRange(RooWorkspace& myws, map<string, string>& par
   int nBins = min(int( round((ctauNResMax - ctauNResMin)/binWidth) ), 1000);
   TH1D* hTot = (TH1D*)myws.data(Form("dOS_%s", label.c_str()))->createHistogram("TMP", *myws.var("ctauNRes"), Binning(nBins, ctauNResMin, ctauNResMax));
   vector<double> rangeCtauNRes;
-  getCtauErrRange(hTot, (int)(ceil(2)), rangeCtauNRes);
+  getRange(hTot, (int)(ceil(2)), rangeCtauNRes);
   hTot->Delete();
   ctauNResMin = rangeCtauNRes[0];
   ctauNResMax = rangeCtauNRes[1];

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauResModel.C
@@ -159,7 +159,6 @@ bool fitCharmoniaCtauResModel( RooWorkspace& myws,             // Local Workspac
     return true;
   }
 
-  myws.Print("v");
   // Fit the Datasets
   if (skipFit==false) {
     bool isWeighted = myws.data(dsName.c_str())->isWeighted();

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaCtauTrueModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaCtauTrueModel.C
@@ -98,7 +98,7 @@ bool fitCharmoniaCtauTrueModel( RooWorkspace& myws,             // Local Workspa
   RooArgSet *newpars = myws.pdf(pdfName.c_str())->getParameters(RooArgSet(*myws.var("ctauTrue")));
   found = found && isFitAlreadyFound(newpars, FileName, pdfName.c_str());
   if (loadFitResult) {
-    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb) ) { skipFit = true; } else  { skipFit = false; }
+    if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, false, false) ) { skipFit = true; } else  { skipFit = false; }
     if (skipFit) { cout << "[INFO] This ctauTrue fit was already done, so I'll load the fit results." << endl; }
     myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()),*newpars,kTRUE);
   } else if (found) {

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaMassModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaMassModel.C
@@ -88,6 +88,7 @@ bool fitCharmoniaMassModel( RooWorkspace& myws,            // Local Workspace
       numEntries = myws.data(dsName.c_str())->sumEntries(); if (numEntries<=0) { doFit = false; }
     }
     else if (doFit && !(myws.data(dsName.c_str()))) { cout << "[ERROR] No local dataset was found to perform the fit!" << endl; return false; }
+    if (myws.data(dsName.c_str())) numEntries = myws.data(dsName.c_str())->sumEntries();
 
     // Set global parameters
     setMassGlobalParameterRange(myws, parIni, cut, incJpsi, incPsi2S, incBkg, wantPureSMC);
@@ -123,6 +124,7 @@ bool fitCharmoniaMassModel( RooWorkspace& myws,            // Local Workspace
       numEntries = myws.data(dsName.c_str())->sumEntries(); if (numEntries<=0) { doFit = false; }
     }
     else if (doFit && !(myws.data(dsName.c_str()))) { cout << "[ERROR] No local dataset was found to perform the fit!" << endl; return false; }
+    if (myws.data(dsName.c_str())) numEntries = myws.data(dsName.c_str())->sumEntries();
       
     // Set global parameters
     setMassGlobalParameterRange(myws, parIni, cut, incJpsi, incPsi2S, incBkg, wantPureSMC);

--- a/HIN-16-004/Fitter/Macros/fitCharmoniaMassModel.C
+++ b/HIN-16-004/Fitter/Macros/fitCharmoniaMassModel.C
@@ -33,7 +33,7 @@ bool fitCharmoniaMassModel( RooWorkspace& myws,            // Local Workspace
                             bool doSimulFit  = false,      // Do simultaneous fit
                             bool wantPureSMC = false,      // Flag to indicate if we want to fit pure signal MC
                             const char* applyCorr ="",     // Flag to indicate if we want corrected dataset and which correction
-                            bool loadFitResult = false,    // Load previous fit results
+                            uint loadFitResult = false,    // Load previous fit results
                             string inputFitDir = "",       // Location of the fit results
                             int  numCores    = 2,          // Number of cores used for fitting
                             // Select the drawing options
@@ -167,8 +167,8 @@ bool fitCharmoniaMassModel( RooWorkspace& myws,            // Local Workspace
     myws.saveSnapshot("simPdf_parIni", *newpars, kTRUE);
     found = found && isFitAlreadyFound(newpars, FileName, "simPdf");
     if (loadFitResult) {
-      if ( loadPreviousFitResult(myws, FileName, DSTAG, false, cutSideBand) ) { skipFit = true; } else { skipFit = false; }
-      if ( loadPreviousFitResult(myws, FileName, DSTAG, true, cutSideBand)  ) { skipFit = true; } else { skipFit = false; }
+      if ( loadPreviousFitResult(myws, FileName, DSTAG, false, (!isMC && !cutSideBand && loadFitResult==1), loadFitResult==1) ) { skipFit = true; } else { skipFit = false; }
+      if ( loadPreviousFitResult(myws, FileName, DSTAG, true, (!isMC && !cutSideBand && loadFitResult==1), loadFitResult==1)  ) { skipFit = true; } else { skipFit = false; }
       if (skipFit) { cout << "[INFO] This simultaneous mass fit was already done, so I'll load the fit results." << endl; }
       myws.saveSnapshot("simPdf_parLoad", *newpars, kTRUE);
     } else if (found) {
@@ -216,9 +216,9 @@ bool fitCharmoniaMassModel( RooWorkspace& myws,            // Local Workspace
     RooArgSet *newpars = myws.pdf(pdfName.c_str())->getParameters(*(myws.var("invMass")));
     found = found && isFitAlreadyFound(newpars, FileName, pdfName.c_str());
     if (loadFitResult) {
-        if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, cutSideBand) ) { skipFit = true; } else { skipFit = false; } 
-        if (skipFit) { cout << "[INFO] This mass fit was already done, so I'll load the fit results." << endl; }
-        myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()), *newpars, kTRUE);
+      if ( loadPreviousFitResult(myws, FileName, DSTAG, isPbPb, (!isMC && !cutSideBand && loadFitResult==1), loadFitResult==1) ) { skipFit = true; } else { skipFit = false; } 
+      if (skipFit) { cout << "[INFO] This mass fit was already done, so I'll load the fit results." << endl; }
+      myws.saveSnapshot(Form("%s_parLoad", pdfName.c_str()), *newpars, kTRUE);
     } else if (found) {
       cout << "[INFO] This mass fit was already done, so I'll just go to the next one." << endl;
       return true;


### PR DESCRIPTION
Added the following fixes to SPlot Algo;

1) Update the number of events (Bkg and Signal) if the local dataset is not equivalent to the one used in mass fits.
2) If the fits have already been done, load the yields if the local dataset and the fitted datasets are equivalent
3) Fixed bug in number of events when loading mass fits (does not have an impact)

Fixed the problems with the pp 2D fits using templates by adding a min ctau cut.

Implemented the Jpsi ctau fits using SPlot Jpsi enhanced DataSets.

This only affects the ctauResData and ctauSB fits which are done using SPlot.